### PR TITLE
Fix for passing headers in transformRequest not just URL

### DIFF
--- a/frameworks/reactish.js
+++ b/frameworks/reactish.js
@@ -24,14 +24,16 @@ export default function reactish (legendSymbol, createElement, {useState, useEff
     );
   }
 
+  const transformRequestFallback = (url) => {
+    return {url: url};
+  };
+
   return function Component (props) {
     const {zoom, layer} = props;
     const spriteUrl = props.sprite;
     const [sprite, setSprite] = useState(null);
 
-    const transformRequest = props.transformRequest || function (url) {
-      return {url: url};
-    };
+    const transformRequest = props.transformRequest || transformRequestFallback;
 
     useEffect(() => {
       let promise;
@@ -64,7 +66,7 @@ export default function reactish (legendSymbol, createElement, {useState, useEff
           }
         }
       }
-    }, [spriteUrl]);
+    }, [spriteUrl, transformRequest]);
 
     const tree = legendSymbol({sprite, zoom, layer});
     return asReact(tree);

--- a/src/util.js
+++ b/src/util.js
@@ -156,7 +156,7 @@ function removeUrl (obj) {
 }
 
 function loadImageViaFetch (url, init) {
-  return fetch(url, removeUrl(init))
+  return fetch(url, init)
     .then(res => res.blob())
     .then(blob => URL.createObjectURL(blob))
     .then(url => loadImageViaTag(url));
@@ -166,7 +166,7 @@ export function loadImage (url, {transformRequest}) {
   const fetchObj = {...transformRequest(url)};
 
   if (fetchObj.headers) {
-    return loadImageViaFetch(url);
+    return loadImageViaFetch(url, removeUrl(fetchObj));
   }
   else {
     return loadImageViaTag(url);


### PR DESCRIPTION
Fix for passing `headers` in `transformRequest` previously only passing URL.

Bug found by @tnsivanagarajan, thanks!